### PR TITLE
(fix) vcards with photos not added to addressbook

### DIFF
--- a/chrome/content/sogo-connector/general/vcards.utils.js
+++ b/chrome/content/sogo-connector/general/vcards.utils.js
@@ -881,7 +881,7 @@ function deducePhotoTypeFromExt(photoName) {
 function photoFileFromName(photoName, inSOGoCache) {
     let file = Components.classes["@mozilla.org/file/directory_service;1"]
                          .getService(Components.interfaces.nsIProperties)
-                         .get("ProfD", Components.interfaces.nsILocalFile);
+                         .get("ProfD", Components.interfaces.nsIFile);
     file.append(inSOGoCache ? kPhotoImageCache : "Photos");
     if (photoName) {
         //dump("photoFileFromName() got photoName = " +photoName+ "\n");


### PR DESCRIPTION
 *Changed line 884 in vcards.utils.js to use nsIFile instead of nsILocalFile.

This is to fix an issue where remote contacts with photos cannot be downloaded into an addressbook in Thunderbird 60. An error occurs with vcards.utils.js when fetching a photo.

Error message: [Exception... "Could not convert JavaScript argument arg 1 [nsIProperties.get]"  nsresult: "0x80570009 (NS_ERROR_XPC_BAD_CONVERT_JS)"  location: "JS frame :: chrome://sogo-connector/content/general/vcards.utils.js :: photoFileFromName :: line 882"  data: no]

Updated nsILocalFile to nsIFile as per https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Using_nsIDirectoryService

