### PR TITLE
rely on $PATH to find zip and bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ VERSION=68.0.0
 
 XPI_ARCHIVE = $(PACKAGE)-$(VERSION)-$(GIT_REV).xpi
 
-SHELL = /bin/bash
-ZIP = /usr/bin/zip
+SHELL=bash
+ZIP=zip
 
 FILENAMES = $(shell cat MANIFEST)
 


### PR DESCRIPTION
rely on $PATH to find zip and bash, fixes build on *BSD